### PR TITLE
fixed geometry processing not being able to process sdf functions

### DIFF
--- a/DeepSDFStruct/sampling.py
+++ b/DeepSDFStruct/sampling.py
@@ -331,9 +331,12 @@ class SDFSampler:
                 if os.path.isfile(fname):
                     logger.warning(f"File {fname} already exists")
                     continue
-                sdf = self.get_sdf_from_geometry(
-                    geometry, n_faces, self.unify_multipatches
-                )
+                if not isinstance(geometry, SDFBase):
+                    sdf = self.get_sdf_from_geometry(
+                        geometry, n_faces, self.unify_multipatches
+                    )
+                else:
+                    sdf = geometry
                 sampled_sdf = random_sample_sdf(
                     sdf,
                     bounds=(-1, 1),


### PR DESCRIPTION
This pull request introduces a small but important update to the `process_geometries` function in `DeepSDFStruct/sampling.py`. The change improves how SDF objects are handled by checking if a geometry is already an instance of `SDFBase`, avoiding unnecessary conversion.

- Logic improvement for geometry processing:
  * Updated `process_geometries` to check if `geometry` is an instance of `SDFBase` before attempting to convert it, ensuring that already-converted SDF objects are used directly.