### PR TITLE
removed unify multipatch option

### DIFF
--- a/DeepSDFStruct/sampling.py
+++ b/DeepSDFStruct/sampling.py
@@ -232,7 +232,6 @@ def process_single_geometry(args):
         geometry,
         outdir,
         dataset_name,
-        unify_multipatches,
         n_faces,
         n_samples,
         sampling_strategy,
@@ -254,7 +253,7 @@ def process_single_geometry(args):
         logger.warning(f"File {fname} already exists")
         return
 
-    sdf = get_sdf_from_geometry(geometry, n_faces, unify_multipatches)
+    sdf = get_sdf_from_geometry(geometry, n_faces)
     pos, neg = sample_sdf(
         sdf, show=show, n_samples=n_samples, sampling_strategy=sampling_strategy
     )
@@ -268,14 +267,12 @@ class SDFSampler:
         outdir,
         splitdir,
         dataset_name,
-        unify_multipatches=True,
         stds=[0.05, 0.025],
         overwrite_existing=False,
     ) -> None:
         self.outdir = outdir
         self.splitdir = splitdir
         self.dataset_name = dataset_name
-        self.unify_multipatches = unify_multipatches
         self.geometries = {}
         self.stds = stds
         folder_name = pathlib.Path(outdir) / dataset_name
@@ -302,9 +299,7 @@ class SDFSampler:
             for instance_id, geometry in tqdm(
                 instance_list.items(), desc="Processing instances"
             ):
-                sdf = self.get_sdf_from_geometry(
-                    geometry, n_faces, self.unify_multipatches
-                )
+                sdf = self.get_sdf_from_geometry(geometry, n_faces)
                 sdf_list.append(sdf)
         return sdf_list
 
@@ -313,7 +308,6 @@ class SDFSampler:
         sampling_strategy="uniform",
         n_faces=100,
         n_samples: int = 1e5,
-        unify_multipatches=True,
         add_surface_samples=True,
         also_save_vtk=False,
     ):
@@ -332,9 +326,7 @@ class SDFSampler:
                     logger.warning(f"File {fname} already exists")
                     continue
                 if not isinstance(geometry, SDFBase):
-                    sdf = self.get_sdf_from_geometry(
-                        geometry, n_faces, self.unify_multipatches
-                    )
+                    sdf = self.get_sdf_from_geometry(geometry, n_faces)
                 else:
                     sdf = geometry
                 sampled_sdf = random_sample_sdf(
@@ -382,29 +374,10 @@ class SDFSampler:
             json.dump(summary, f, indent=4)
 
     def get_sdf_from_geometry(
-        self,
-        geometry,
-        n_faces: int,
-        unify_multipatches: bool = True,
-        threshold: float = 1e-5,
+        self, geometry, n_faces: int, threshold: float = 1e-5
     ) -> SDFfromMesh:
         if isinstance(geometry, splinepy.Multipatch):
-            if unify_multipatches:
-                patch_meshs = []
-                for patch in geometry.patches:
-                    patch_faces = patch.extract.faces(n_faces)
-                    patch_mesh = trimesh.Trimesh(
-                        vertices=patch_faces.vertices, faces=patch_faces.faces
-                    )
-                    # add all patches as meshs to one boolean addition
-                    patch_meshs.append(SDFfromMesh(patch_mesh))
-                sdf_geom = patch_meshs[0]
-                for pm in patch_meshs[1:]:
-                    sdf_geom = sdf_geom + pm
-            else:
-                sdf_geom = SDFfromMesh(
-                    geometry.extract.faces(n_faces), threshold=threshold
-                )
+            sdf_geom = SDFfromMesh(geometry.extract.faces(n_faces), threshold=threshold)
         elif isinstance(geometry, trimesh.Trimesh):
             sdf_geom = SDFfromMesh(geometry, threshold=threshold)
 

--- a/tests/test_sdf_functions.py
+++ b/tests/test_sdf_functions.py
@@ -2,9 +2,45 @@ import gustaf as gus
 import torch
 import numpy as np
 import itertools
-from DeepSDFStruct.SDF import SDFfromLineMesh, CappedBorderSDF
+import splinepy
+from DeepSDFStruct.SDF import SDFfromLineMesh, CappedBorderSDF, SDFfromMesh
 from DeepSDFStruct.mesh import export_sdf_grid_vtk, export_surface_mesh, create_3D_mesh
 from DeepSDFStruct.sdf_primitives import CrossMsSDF
+
+
+def test_sdf_from_multipatch_cubes_equivalence():
+
+    # --- define cubes ---
+    cube1 = splinepy.helpme.create.box(1.0, 1.0, 1.0)
+
+    cube2 = splinepy.helpme.create.box(1.0, 1.0, 1.0)
+    cube2.control_points[:, 0] = cube2.control_points[:, 0] + 1
+    big_cube = splinepy.helpme.create.box(2.0, 1.0, 1.0)
+
+    multipatch = splinepy.Multipatch([cube1, cube2])
+
+    n = 30
+    xs = torch.linspace(-0.5, 2.5, n)
+    ys = torch.linspace(-0.5, 1.5, n)
+    zs = torch.linspace(-0.5, 1.5, n)
+
+    queries = torch.stack(torch.meshgrid(xs, ys, zs, indexing="ij"), dim=-1).reshape(
+        -1, 3
+    )
+
+    multipatch_sdf = SDFfromMesh(multipatch.extract.faces(30))
+    big_cube_sdf = SDFfromMesh(big_cube.extract.faces(30))
+
+    vals_multipatch = multipatch_sdf(queries)
+    vals_big_cube = big_cube_sdf(queries)
+
+    torch.testing.assert_close(
+        vals_multipatch,
+        vals_big_cube,
+        atol=1e-2,
+        rtol=1e-2,
+        msg="Unified multipatch does not match single large cube",
+    )
 
 
 def test_cap_border_dict():
@@ -76,5 +112,6 @@ if __name__ == "__main__":
     import warnings
 
     warnings.filterwarnings("error")
+    test_sdf_from_multipatch_cubes_equivalence()
     test_cap_border_dict()
     test_sdf_from_linemesh()


### PR DESCRIPTION
The new scaling function introduced issues, when each multipatch is passed in separately. However, the faces can be extracted directly on the multipatch, without changing the result. I added a test to prove this.