### PR TITLE
Change publish trigger to version tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,6 @@ name: Publish to PyPI
 
 on:
   push:
-    branches: [main]
     tags:
       - "v*"
 


### PR DESCRIPTION
Update the workflow to trigger on version tags instead of main branch pushes.